### PR TITLE
#18 Added support for Template datum computation to skip string evaluation when Template pointer is null/empty

### DIFF
--- a/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/datum/compute/TemplateTest.kt
+++ b/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/datum/compute/TemplateTest.kt
@@ -38,14 +38,20 @@ class TemplateTest : TestCase() {
         Template("").printJsonTest()
         Template("{/a} then {/b/c}").printJsonTest()
 
+        // TODO fix serialization (Elisha)
         println(ObjectMapper().convertValue<Template>("{/a} then {/b/c}").simpleValue)
         println(jacksonObjectMapper().convertValue<Template>("{/a} then {/b/c}").simpleValue)
     }
 
     @Test
     fun testApply() {
-        val tf = Template("{/a} then {/b/c}")
+        val tf = Template("{/a} then {/b/c}", true)
 
+        assertEquals(null, tf(emptyMap<String, Any>()))
+        assertEquals(null, tf(mapOf("a" to "one")))
+        assertEquals(null, tf(mapOf("a" to "", "b" to mapOf("c" to ""))))
+
+        tf.skipOnEmpty = false
         assertEquals("null then null", tf(emptyMap<String, Any>()))
         assertEquals("one then null", tf(mapOf("a" to "one")))
         assertEquals("one then two", tf(mapOf("a" to "one", "b" to mapOf("c" to "two"))))


### PR DESCRIPTION
In conjunction with the following edata-kt changes:
https://gitlab.jhuapl.edu/polaris/data/edata-kt/-/merge_requests/29

![Capture](https://github.com/user-attachments/assets/f2d079d1-685d-4ed6-8563-8c8282974655)

![Capture1](https://github.com/user-attachments/assets/18838010-62a6-4dce-9ec5-028518d4944d)
