### PR TITLE
fix: correct timezone-dependent test expectations

### DIFF
--- a/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/EtlTest.kt
+++ b/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/EtlTest.kt
@@ -41,6 +41,8 @@ import edu.jhuapl.testkt.prettyPrintJsonTest
 import edu.jhuapl.testkt.prettyPrintYamlTest
 import junit.framework.TestCase
 import java.io.IOException
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class EtlTest : TestCase() {
 
@@ -90,7 +92,13 @@ class EtlTest : TestCase() {
         res.load.fields.add(FieldEncode<Long>("start", Field("Date"), As(Long::class.java)))
         res.load.fields.add(FieldEncode<String>("sensor", Constant("my sensor")))
         val input = mapOf("Date" to "09/11/1980 02:03", "SrcPort" to "25", "Sensor" to "a sensor")
-        assertEquals(337500180000L, res(input)!!["start"])
+        // "Date" has no zone/offset, so decoding intentionally applies the JVM's default zone
+        // (see InstantDecoder) -- compute the expected value the same way instead of a
+        // hardcoded literal tied to one specific zone (this used to assume America/New_York,
+        // which made the test fail on UTC CI runners; see issue #45).
+        val expectedMillis = LocalDateTime.of(1980, 9, 11, 2, 3)
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        assertEquals(expectedMillis, res(input)!!["start"])
     }
 
     fun testMapToObject() {

--- a/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/decode/DecoderGuesserTest.kt
+++ b/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/decode/DecoderGuesserTest.kt
@@ -51,15 +51,18 @@ class DecoderGuesserTest {
         assertTimestamp(1980, 9, 11, 0, 0, 0, 0, "Sep 11, 1980")
         assertTimestamp(2017, 10, 31, 16, 40, 10, 132000000, "2017-10-31T16:40:10.132")
         assertTimestampFails(2017, 10, 31, 16, 40, 10, 130000000, "2017-10-31T16:40:10.13")
-        //todo - these next two tests need to be adapted for zulu offset (daylight savings)
-        assertTimestamp(2017, 10, 31, 12, 41, 13, 196000000, "2017-10-31T16:41:13.196Z")
-        assertTimestamp(2017, 10, 31, 12, 41, 13, 196471100, "2017-10-31T16:41:13.1964711Z")
+        // These two inputs end in 'Z' (Zulu/UTC), which DATE_TIME decodes as an explicit,
+        // zone-independent instant rather than applying the system default zone -- so the
+        // expected value here must be built against UTC, not the local zone. See issue #45.
+        assertTimestamp(2017, 10, 31, 16, 41, 13, 196000000, "2017-10-31T16:41:13.196Z", zulu = true)
+        assertTimestamp(2017, 10, 31, 16, 41, 13, 196471100, "2017-10-31T16:41:13.1964711Z", zulu = true)
     }
 
     @Suppress("unused")
-    private fun assertTimestamp(yr: Int, mo: Int, day: Int, hr: Int, min: Int, sec: Int, nanos: Int, date: String) {
+    private fun assertTimestamp(yr: Int, mo: Int, day: Int, hr: Int, min: Int, sec: Int, nanos: Int, date: String, zulu: Boolean = false) {
         val d = LocalDateTime.of(yr, mo, day, hr, min, sec, nanos)
-        DATE_TIME.decode(date) shouldBe d.toLocalInstant()
+        val expected = if (zulu) d.atZone(ZoneId.of("Z")).toInstant() else d.toLocalInstant()
+        DATE_TIME.decode(date) shouldBe expected
     }
 
     @Suppress("unused")

--- a/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/decode/InstantDecoderTest.kt
+++ b/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/decode/InstantDecoderTest.kt
@@ -60,11 +60,14 @@ class InstantDecoderTest {
         assertTimestampFails(inst4, 2017, 10, 31, 16, 40, 10, 132000000, "2017-10-31T16:40:10.132")
         assertTimestampFails(inst4, 2017, 10, 31, 16, 40, 10, 130000000, "2017-10-31T16:40:10.13")
         assertTimestampFails(inst4, 2017, 10, 31, 16, 40, 10, 100000000, "2017-10-31T16:40:10.1")
-        assertTimestamp(inst4, 2017, 10, 31, 12, 41, 13, 196000000, "2017-10-31T16:41:13.196Z")
+        // Pattern ends in 'Z' (Zulu/UTC), which InstantDecoder decodes as an explicit,
+        // zone-independent instant rather than applying the system default zone -- so the
+        // expected value here must be built against UTC, not the local zone. See issue #45.
+        assertTimestamp(inst4, 2017, 10, 31, 16, 41, 13, 196000000, "2017-10-31T16:41:13.196Z", zulu = true)
         assertTimestampFails(inst4, 2017, 10, 31, 12, 41, 13, 196000000, "2017-10-31T16:41:13.1964711Z")
 
         val inst5 = InstantDecoder("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
-        assertTimestamp(inst5, 2017, 10, 31, 12, 41, 13, 196471000, "2017-10-31T16:41:13.196471Z")
+        assertTimestamp(inst5, 2017, 10, 31, 16, 41, 13, 196471000, "2017-10-31T16:41:13.196471Z", zulu = true)
         assertTimestampFails(inst5, 2017, 10, 31, 12, 41, 13, 196000000, "2017-10-31T16:41:13.196Z")
 
         val inst6 = InstantDecoder("EEE MMM d HH:mm:ss yyyy")
@@ -76,8 +79,10 @@ class InstantDecoderTest {
         assertTimestamp(InstantDecoder("yyyy/MM/dd"), 2012, 1, 1, 0, 0, 0, 0, "2012/01/01")
     }
 
-    private fun assertTimestamp(dec: InstantDecoder, yr: Int, mo: Int, day: Int, hr: Int, min: Int, sec: Int, nanos: Int, date: String) {
-        dec.decode(date) shouldBe LocalDateTime.of(yr, mo, day, hr, min, sec, nanos).toLocalInstant()
+    private fun assertTimestamp(dec: InstantDecoder, yr: Int, mo: Int, day: Int, hr: Int, min: Int, sec: Int, nanos: Int, date: String, zulu: Boolean = false) {
+        val d = LocalDateTime.of(yr, mo, day, hr, min, sec, nanos)
+        val expected = if (zulu) d.atZone(ZoneId.of("Z")).toInstant() else d.toLocalInstant()
+        dec.decode(date) shouldBe expected
     }
 
     private fun assertTimestampFails(dec: InstantDecoder, yr: Int, mo: Int, day: Int, hr: Int, min: Int, sec: Int, nanos: Int, date: String) {

--- a/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/value/compute/TypesTest.kt
+++ b/parsnip/src/test/kotlin/edu/jhuapl/data/parsnip/value/compute/TypesTest.kt
@@ -40,7 +40,13 @@ class TypesTest {
     @Test
     fun testAs_Invoke() {
         As(Date::class.java).invoke("2012-07-16 19:35:06.000") shouldBe Date(112, 6, 16, 19, 35, 6)
-        As(Long::class.java).invoke("2012-07-16 19:35:06.000") shouldBe 1342481706000L
+        // Input has no zone/offset, so decoding intentionally applies the JVM's default zone
+        // (see InstantDecoder) -- compute the expected value the same way instead of a
+        // hardcoded literal tied to one specific zone (this used to assume America/New_York,
+        // which made the test fail on UTC CI runners; see issue #45).
+        val expectedMillis = LocalDateTime.parse("2012-07-16T19:35:06.000")
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        As(Long::class.java).invoke("2012-07-16 19:35:06.000") shouldBe expectedMillis
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes 4 tests that hardcoded a date/time expectation computed on a machine in America/New_York, causing failures on GitHub's UTC CI runners by exactly 4 hours (`EtlTest.testDatesAsLongs`, `TypesTest.testAs_Invoke`, `DecoderGuesserTest.testTimestamp`, `InstantDecoderTest.testCanTransform`).

Two different root causes, both zone-related:

- **Zone-less inputs** (`EtlTest`, `TypesTest`): decoding a date/time string with no zone/offset intentionally applies the JVM's default zone (documented `InstantDecoder` behavior — this is the intended design, confirmed with the maintainer). The tests hardcoded a literal expected value tied to one specific zone instead of computing it the same way the decoder does. Fixed by computing the expected value dynamically via `ZoneId.systemDefault()` at test-run time.
- **`'Z'`-suffixed inputs** (`DecoderGuesserTest`, `InstantDecoderTest`): a literal `'Z'` in the pattern means `InstantDecoder` treats it as explicit UTC/Zulu — a zone-independent instant — but the tests built their expected value via `ZoneId.systemDefault()` regardless, which only happened to match on a UTC-4 machine. Fixed by adding a `zulu` parameter to each `assertTimestamp` helper so the `'Z'` cases build their expected instant against `ZoneId.of("Z")` instead. This also resolves the `//todo` comment already in `DecoderGuesserTest.kt` flagging this exact issue.

## Test plan

- [x] `mvn test -Dtest=EtlTest,TypesTest,DecoderGuesserTest,InstantDecoderTest` — pass locally
- [x] Same 4 classes re-run with `-Duser.timezone=UTC` — pass (confirms portability, reproducing the CI environment)
- [x] Full `parsnip` suite (183 tests) run with `-Duser.timezone=UTC` — all pass

Closes #45
