### PR TITLE
chore: dependency maintenance - jackson 3.2.1 + minor plugin bumps

### DIFF
--- a/parsnip-types/pom.xml
+++ b/parsnip-types/pom.xml
@@ -50,9 +50,9 @@
         <license.organizationName>Johns Hopkins University Applied Physics Laboratory</license.organizationName>
         <license.licenseName>apache_v2</license.licenseName>
         <guava.version>33.6.0-jre</guava.version>
-        <jackson.version>3.1.3</jackson.version>
+        <jackson.version>3.2.1</jackson.version>
         <kotlin.version>2.4.10</kotlin.version>
-        <kotlin-dokka.version>2.1.0</kotlin-dokka.version>
+        <kotlin-dokka.version>2.2.0</kotlin-dokka.version>
     </properties>
 
     <dependencies>
@@ -164,7 +164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -264,7 +264,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -296,7 +296,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.10.1</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -327,7 +327,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.10.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/parsnip/pom.xml
+++ b/parsnip/pom.xml
@@ -50,8 +50,8 @@
         <license.organizationName>Johns Hopkins University Applied Physics Laboratory</license.organizationName>
         <license.licenseName>apache_v2</license.licenseName>
         <kotlin.version>2.4.10</kotlin.version>
-        <kotlin-dokka.version>2.1.0</kotlin-dokka.version>
-        <jackson.version>3.1.3</jackson.version>
+        <kotlin-dokka.version>2.2.0</kotlin-dokka.version>
+        <jackson.version>3.2.1</jackson.version>
         <javafx.version>21.0.9</javafx.version>
     </properties>
 
@@ -200,7 +200,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -301,7 +301,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -333,7 +333,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.10.1</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -364,7 +364,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.10.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary
- Bump jackson.version 3.1.3 to 3.2.1 (jackson-databind, jackson-dataformat-yaml, jackson-module-kotlin) - resolves all 9 open Dependabot security alerts (2 high, 7 moderate)
- Batch minor build-plugin bumps in both modules: maven-compiler-plugin 3.13.0 to 3.15.0, maven-javadoc-plugin 3.10.1 to 3.12.0, maven-source-plugin 3.1.0 to 3.4.0, dokka-maven-plugin 2.1.0 to 2.2.0, central-publishing-maven-plugin 0.10.0 to 0.11.0

Deferred to a future cycle (see #47): kotlin/kotlin-maven-plugin (Beta2 pre-release), javafx (early-access build), maven-site-plugin (milestone), license-maven-plugin (major, needs its own changelog review), maven-enforcer-plugin/maven-gpg-plugin/maven-release-plugin (major build-time-only bumps not taken this cycle).

Ref #47

## Test plan
- [x] cd parsnip-types && mvn install - 26 tests, BUILD SUCCESS
- [x] cd parsnip && mvn test - 183 tests, BUILD SUCCESS
- [ ] CI green
- [ ] Human review + merge (per repo policy, agent does not merge dependency-update PRs)

Generated with Claude Code
